### PR TITLE
chore: update server ports for new VM configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
 ## Server (API)
 
-- 개발 실행: cd server && npm run dev (기본 포트 4000)
-- 헬스체크: GET http://localhost:4000/health
+ - 개발 실행: cd server && npm run dev (기본 포트 80)
+ - 헬스체크: GET http://34.47.82.64/health (외부) / http://10.178.0.2/health (내부)
 - API 베이스: /api
 - 현재 인메모리 저장소(빠른 프로토타입). 추후 DB 교체 권장.
 
@@ -45,8 +45,9 @@ pm run ios
 - 경로: spring-server
 - 실행 전제: JDK 17+, JAVA_HOME 설정
 - 실행: cd spring-server && mvnw.cmd spring-boot:run 또는 mvnw.cmd -DskipTests package 후 java -jar target/*.jar
-- 포트: 8080
-- 헬스체크: GET http://localhost:8080/health
+ - 포트: 80
+ - 헬스체크: GET http://34.47.82.64/health (외부) / http://10.178.0.2/health (내부)
+ - 루트: GET http://34.47.82.64/ (헬스 정보 반환)
 - API 베이스: /api
 
 ### 엔드포인트(동일 스펙)
@@ -59,16 +60,20 @@ pm run ios
 - 스케줄: GET /api/schedule
 
 ## Flutter 앱
-- 경로: lutter (소스 스켈레톤)
-- 의존성: pubspec.yaml 참고 (http 등)
-- API 주소: lib/api/client.dart 내 piBase (기본 http://localhost:8080)
-- 최초 플랫폼 생성: Flutter SDK가 설치되어 있다면 cd flutter && flutter create . 실행(기존 lib/pubspec 유지)
-- 실행: lutter run -d chrome (웹), 또는 에뮬레이터/실기기에서 lutter run
-- 실기기 접속 시: piBase를 PC IP로 변경 (예: http://192.168.x.x:8080)
+- API 주소: lib/api/client.dart 내 piBase (기본 http://34.47.82.64)
+- 실기기 접속 시: piBase를 PC IP로 변경 (예: http://192.168.x.x)
+  - Node API: server (포트 80)
 
-## 참고
-- 기존 Node/Expo 스택도 유지되어 있습니다.
-  - Node API: server (포트 4000)
+- 가입: POST http://34.47.82.64/api/auth/register body { name, role: worker|manager|admin } → { token, user }
+- 로그인: POST http://34.47.82.64/api/auth/login body { userId? , name? } → { token, user }
+- 클라이언트: Authorization: Bearer <token> 헤더 첨부
+- 응답 스키마는 기존과 동일(예: 공지 
+eadBy는 문자열 배열)
+
+
+  const socket = io('http://34.47.82.64', { transports: ['websocket'] })
+  final socket = IO.io('http://34.47.82.64', IO.OptionBuilder().setTransports(['websocket']).build());
+  ```
   - Expo RN: mobile (API 주소는 mobile/app.json에서 설정)
 
 

--- a/flutter/lib/api/client.dart
+++ b/flutter/lib/api/client.dart
@@ -1,7 +1,7 @@
 ﻿import 'dart:convert';
 import 'package:http/http.dart' as http;
 
-const String apiBase = String.fromEnvironment('API_BASE_URL', defaultValue: 'http://localhost:4000');
+const String apiBase = String.fromEnvironment('API_BASE_URL', defaultValue: 'http://34.47.82.64');
 
 class ApiClient {
   final String base;

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -26,7 +26,7 @@
                              "favicon":  "./assets/favicon.png"
                          },
                  "extra":  {
-                               "API_BASE_URL":  "http://localhost:4000"
+                               "API_BASE_URL":  "http://34.47.82.64"
                            }
              }
 }

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -1,7 +1,7 @@
 ﻿import Constants from 'expo-constants';
 import axios from 'axios';
 
-const defaultBaseURL = 'http://localhost:4000';
+const defaultBaseURL = 'http://34.47.82.64';
 const extra = (Constants.expoConfig?.extra as any) || {};
 export const api = axios.create({ baseURL: extra.API_BASE_URL || defaultBaseURL });
 

--- a/mobile/src/realtime/RealtimeContext.tsx
+++ b/mobile/src/realtime/RealtimeContext.tsx
@@ -24,7 +24,7 @@ export function RealtimeProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     const extra: any = Constants.expoConfig?.extra || {};
-    const baseUrl: string = extra.API_BASE_URL || 'http://localhost:4000';
+    const baseUrl: string = extra.API_BASE_URL || 'http://34.47.82.64';
     const socket: Socket = io(baseUrl, { transports: ['websocket'], auth: token ? { token } : undefined });
 
     socket.on('connect', () => setConnected(true));

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -76,9 +76,10 @@ function cleanupUploads() {
 setInterval(cleanupUploads, 24 * 60 * 60 * 1000);
 setTimeout(cleanupUploads, 10_000);
 
-const PORT = process.env.PORT ? Number(process.env.PORT) : 4000;
+const PORT = process.env.PORT ? Number(process.env.PORT) : 80;
+const HOST = process.env.HOST || '0.0.0.0';
 const server = createServer(app);
-server.listen(PORT, () => {
+server.listen(PORT, HOST, () => {
   initRealtime(server);
-  console.log(`[familyone] API listening on http://localhost:${PORT}`);
+  console.log(`[familyone] API listening on http://${HOST}:${PORT}`);
 });

--- a/spring-server/src/main/java/com/familyone/api/HealthController.java
+++ b/spring-server/src/main/java/com/familyone/api/HealthController.java
@@ -6,6 +6,10 @@ import java.util.*;
 
 @RestController
 public class HealthController {
+  @GetMapping("/")
+  public Map<String,Object> root(){
+    return health();
+  }
   @GetMapping("/health")
   public Map<String,Object> health(){
     return Map.of("ok", true, "service", "familyone-spring", "now", java.time.Instant.now().toString());

--- a/spring-server/src/main/resources/application.properties
+++ b/spring-server/src/main/resources/application.properties
@@ -1,2 +1,2 @@
 ﻿spring.application.name=familyone-spring
-server.port=8080
+server.port=80


### PR DESCRIPTION
## Summary
- default Node and Spring servers to port 80 and update health check docs
- point Flutter and React Native clients to remote IP without custom port
- document websocket examples using new base URL

## Testing
- `npm test` (server) *(fails: Error: no test specified)*
- `npm run lint` (server) *(fails: Missing script: "lint")*
- `npm test` (mobile) *(fails: Missing script: "test")*
- `npm run lint` (mobile) *(fails: Missing script: "lint")*
- `flutter test` *(fails: command not found: flutter)*
- `flutter analyze` *(fails: command not found: flutter)*
- `bash mvnw test` (spring-server) *(fails: Failed to fetch apache-maven)*
- `bash mvnw -q checkstyle:check` (spring-server) *(fails: Failed to fetch apache-maven)*

------
https://chatgpt.com/codex/tasks/task_e_68b707cc61988326a93a189be975b9f3